### PR TITLE
Introduce NewServerPlayer

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ func main() {
             Addr: ":8080",
         }),
         // Sets the timeout waiting for the server to stop.
-        orchestra.WithTimeout(time.Second * 5),
+        orchestra.WithShutdownTimeout(time.Second * 5),
     )
     err := orchestra.PlayUntilSignal(s, os.Interrupt, syscall.SIGTERM)
     if err != nil {

--- a/README.md
+++ b/README.md
@@ -38,12 +38,12 @@ This will start a player with a context, and close the context once it receives 
 Example:
 
 ```go
-package main 
+package main
 
 import (
     "os"
     "syscall"
-    
+
     "github.com/stephenafamo/orchestra"
 )
 
@@ -66,6 +66,7 @@ package main
 import (
     "context"
     "os"
+    "time"
     "syscall"
 
     "github.com/stephenafamo/orchestra"
@@ -96,18 +97,25 @@ Since a very common long running process is the `*http.Server`, this makes it ea
 With the help of multiple helper functions, we can create a gracefully shutting down server that closes on `SIGINT` and `SIGTERM` by:
 
 ```go
-package main 
+package main
 
 import (
     "net/http"
     "os"
     "syscall"
-    
+
     "github.com/stephenafamo/orchestra"
 )
 
 func main() {
-    s := orchestra.ServerPlayer{&http.Server{}}
+    s := orchestra.NewServerPlayer(
+        // Setting the *http.Server
+        orchestra.WithHTTPServer(&http.Server{
+            Addr: ":8080",
+        }),
+        // Sets the timeout waiting for the server to stop.
+        orchestra.WithTimeout(time.Second * 5),
+    )
     err := orchestra.PlayUntilSignal(s, os.Interrupt, syscall.SIGTERM)
     if err != nil {
         panic(err)
@@ -138,7 +146,7 @@ func main() {
     // A player from a function
     a := orchestra.PlayerFunc(myFunction)
     // A player from a server
-    b := orchestra.ServerPlayer{&http.Server{}}
+    b := orchestra.NewServerPlayer()
 
     // A conductor to control them all
     conductor := &orchestra.Conductor{
@@ -202,4 +210,3 @@ The logger can be modified by assiging a logger to `orchestra.Logger`
 ## Contributing
 
 Looking forward to pull requests.
-

--- a/server.go
+++ b/server.go
@@ -10,7 +10,7 @@ import (
 // ServerPlayer is a type that extends the *http.Server
 type ServerPlayer struct {
 	*http.Server
-	Timeout time.Duration
+	ShutdownTimeout time.Duration
 }
 
 // ServerPlayerOption is a function interface to configure the ServerPlayer
@@ -18,8 +18,8 @@ type ServerPlayerOption func(s *ServerPlayer)
 
 func NewServerPlayer(opts ...ServerPlayerOption) *ServerPlayer {
 	s := &ServerPlayer{
-		Server:  &http.Server{},
-		Timeout: 10 * time.Second,
+		Server:          &http.Server{},
+		ShutdownTimeout: 10 * time.Second,
 	}
 	for _, f := range opts {
 		f(s)
@@ -27,10 +27,10 @@ func NewServerPlayer(opts ...ServerPlayerOption) *ServerPlayer {
 	return s
 }
 
-// WithTimeout replaces the default timeout of ServerPlayer
-func WithTimeout(timeout time.Duration) ServerPlayerOption {
+// WithShutdownTimeout sets the shutdown timeout of ServerPlayer (10s by default)
+func WithShutdownTimeout(timeout time.Duration) ServerPlayerOption {
 	return func(s *ServerPlayer) {
-		s.Timeout = timeout
+		s.ShutdownTimeout = timeout
 	}
 }
 
@@ -55,7 +55,7 @@ func (s ServerPlayer) Play(ctxMain context.Context) error {
 
 	select {
 	case <-ctxMain.Done():
-		timeout := s.Timeout
+		timeout := s.ShutdownTimeout
 
 		ctx, cancel := context.WithTimeout(context.Background(), timeout)
 		defer cancel()

--- a/server.go
+++ b/server.go
@@ -18,6 +18,7 @@ type ServerPlayerOption func(s *ServerPlayer)
 
 func NewServerPlayer(opts ...ServerPlayerOption) *ServerPlayer {
 	s := &ServerPlayer{
+		Server:  &http.Server{},
 		Timeout: 10 * time.Second,
 	}
 	for _, f := range opts {

--- a/server_test.go
+++ b/server_test.go
@@ -19,21 +19,21 @@ func TestNewServerPlayer(t *testing.T) {
 		{
 			name: "default",
 			args: args{},
-			want: &ServerPlayer{Server: &http.Server{}, Timeout: time.Second * 10},
+			want: &ServerPlayer{Server: &http.Server{}, ShutdownTimeout: time.Second * 10},
 		},
 		{
 			name: "set timeout to 5s",
 			args: args{opts: []ServerPlayerOption{
-				WithTimeout(time.Second * 5),
+				WithShutdownTimeout(time.Second * 5),
 			}},
-			want: &ServerPlayer{Server: &http.Server{}, Timeout: time.Second * 5},
+			want: &ServerPlayer{Server: &http.Server{}, ShutdownTimeout: time.Second * 5},
 		},
 		{
 			name: "replace default http server",
 			args: args{opts: []ServerPlayerOption{
 				WithHTTPServer(&http.Server{Addr: ":4321"}),
 			}},
-			want: &ServerPlayer{Server: &http.Server{Addr: ":4321"}, Timeout: time.Second * 10},
+			want: &ServerPlayer{Server: &http.Server{Addr: ":4321"}, ShutdownTimeout: time.Second * 10},
 		},
 	}
 	for _, tt := range tests {

--- a/server_test.go
+++ b/server_test.go
@@ -19,21 +19,21 @@ func TestNewServerPlayer(t *testing.T) {
 		{
 			name: "default",
 			args: args{},
-			want: &ServerPlayer{Server: &http.Server{}, ShutdownTimeout: time.Second * 10},
+			want: &ServerPlayer{server: &http.Server{}, shutdownTimeout: time.Second * 10},
 		},
 		{
 			name: "set timeout to 5s",
 			args: args{opts: []ServerPlayerOption{
 				WithShutdownTimeout(time.Second * 5),
 			}},
-			want: &ServerPlayer{Server: &http.Server{}, ShutdownTimeout: time.Second * 5},
+			want: &ServerPlayer{server: &http.Server{}, shutdownTimeout: time.Second * 5},
 		},
 		{
 			name: "replace default http server",
 			args: args{opts: []ServerPlayerOption{
 				WithHTTPServer(&http.Server{Addr: ":4321"}),
 			}},
-			want: &ServerPlayer{Server: &http.Server{Addr: ":4321"}, ShutdownTimeout: time.Second * 10},
+			want: &ServerPlayer{server: &http.Server{Addr: ":4321"}, shutdownTimeout: time.Second * 10},
 		},
 	}
 	for _, tt := range tests {

--- a/server_test.go
+++ b/server_test.go
@@ -1,0 +1,20 @@
+package orchestra
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestNewServerPlayer(t *testing.T) {
+	srv := NewServerPlayer(
+		WithHTTPServer(&http.Server{Addr: "localhost:4321"}),
+		WithTimeout(5*time.Second),
+	)
+	if srv.Addr != "localhost:4321" {
+		t.Errorf(`expected srv.Addr to be "localhost:4321", got: %s`, srv.Addr)
+	}
+	if srv.Timeout != (time.Second * 5) {
+		t.Errorf(`expected srv.Timeout to be "5s", got: %s`, srv.Timeout)
+	}
+}


### PR DESCRIPTION
Commit ac8b89a introduced a breaking change and making it harder to create a `ServerPlayer`. This change will allow users of this package to initiate a `ServerPlayer` with forward compatibility with ease.