### PR TITLE
feat: allow passing context parent context

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ if err != nil {
 
 ## Customization
 
-The logger can be modified by assiging a logger to `orchestra.Logger`
+The logger can be modified by assigning a logger to `orchestra.Logger`
 
 ```go
 type Logger interface {

--- a/player.go
+++ b/player.go
@@ -11,9 +11,9 @@ type Player interface {
 	Play(context.Context) error
 }
 
-// PlayUntilSignal starts the player and stops when it recieves os.Signals
-func PlayUntilSignal(p Player, sig ...os.Signal) error {
-	ctx, cancel := signal.NotifyContext(context.Background(), sig...)
+// PlayUntilSignal starts the player and stops when it receives os.Signals
+func PlayUntilSignal(ctx context.Context, p Player, sig ...os.Signal) error {
+	ctx, cancel := signal.NotifyContext(ctx, sig...)
 	defer cancel()
 
 	return p.Play(ctx)


### PR DESCRIPTION
This PR introduce a new function named `PlayUntilSignalOrContext`.  This
function allow the caller to pass a parent context which can be canceled by
other means other than sending a signal. This is extremely helpful for testing,
where you want to start a server and stop it when the test completed.